### PR TITLE
Connect chat UI to LLM endpoint

### DIFF
--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -1,0 +1,17 @@
+export const fetchLLMResponse = async (prompt: string): Promise<string> => {
+  const response = await fetch("http://localhost:3001/llm", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ prompt }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch LLM response");
+  }
+
+  const data = await response.json();
+  return data.message || "";
+};
+

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -3,6 +3,7 @@ import MessageStream from "./MessageStream";
 import InputBox from "./InputBox";
 import hollyLogo from "../assets/logo.png";
 import useVoiceRecorder from "../hooks/useVoiceRecorder";
+import { fetchLLMResponse } from "../api/llm";
 
 interface Message {
   role: "user" | "assistant";
@@ -23,14 +24,24 @@ const LeftPanel = () => {
 
     setIsThinking(true);
 
-    setTimeout(() => {
-      const hollyReply = {
-        role: "assistant",
-        content: "Holly here — test reply",
-      };
-      setMessages((prev) => [...prev, hollyReply]);
-      setIsThinking(false);
-    }, 1000);
+    fetchLLMResponse(input)
+      .then((reply) => {
+        const hollyReply = {
+          role: "assistant" as const,
+          content: reply,
+        };
+        setMessages((prev) => [...prev, hollyReply]);
+      })
+      .catch(() => {
+        const hollyReply = {
+          role: "assistant" as const,
+          content: "Sorry, something went wrong.",
+        };
+        setMessages((prev) => [...prev, hollyReply]);
+      })
+      .finally(() => {
+        setIsThinking(false);
+      });
   };
 
   const toggleMode = () => {


### PR DESCRIPTION
## Summary
- add fetchLLMResponse helper to post prompts to http://localhost:3001/llm
- wire LeftPanel chat handler to call LLM API and render replies or errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68935d5ec4608329ab24217b824ab0eb