### PR TITLE
Handle raw JSON LLM response on frontend

### DIFF
--- a/src/api/llm.ts
+++ b/src/api/llm.ts
@@ -11,7 +11,15 @@ export const fetchLLMResponse = async (prompt: string): Promise<string> => {
     throw new Error("Failed to fetch LLM response");
   }
 
-  const data = await response.json();
-  return data.message || "";
+  const data: any = await response.json();
+
+  // Support common LLM response shapes
+  return (
+    data?.choices?.[0]?.message?.content || // OpenAI-style chat completion
+    data?.choices?.[0]?.text || // Completion APIs
+    data?.message ||
+    data?.response ||
+    JSON.stringify(data)
+  );
 };
 


### PR DESCRIPTION
## Summary
- Parse common LLM response structures and fall back to raw JSON so chat box displays replies properly.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: JSX configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_689386b07d408329aef6f413c8337538