### PR TITLE
feat: add launch script implementation

### DIFF
--- a/launch-dev.js
+++ b/launch-dev.js
@@ -1,0 +1,36 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function run(command, options = {}) {
+  return spawn(command, { stdio: 'inherit', shell: true, ...options });
+}
+
+const processes = [
+  run('ssh -L 11111:localhost:11434 -p 50015 root@99.243.100.183'),
+  run('node server.js', { cwd: path.resolve(__dirname, '../holly-backend') }),
+  run('npm run dev', { cwd: __dirname })
+];
+
+function shutdown() {
+  for (const p of processes) {
+    if (!p.killed) {
+      p.kill('SIGINT');
+    }
+  }
+}
+
+process.on('SIGINT', () => {
+  shutdown();
+  process.exit();
+});
+
+process.on('SIGTERM', () => {
+  shutdown();
+  process.exit();
+});
+
+process.on('exit', shutdown);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "launch": "node launch-dev.js"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary
- add `launch-dev.js` to spawn ssh tunnel, backend server, and frontend dev server
- expose `npm run launch` script alias for dev setup

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68938966d2c08329bcb961e312150399