### PR TITLE
feat: stream tts playback

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,42 +1,50 @@
+import { useEffect } from "react";
 import LeftPanel from "./components/LeftPanel";
 import MainWindow from "./components/MainWindow";
 import RightBar from "./components/RightBar";
+import InputBox from "./components/InputBox";
 import { useTTS } from "./useTTS";
 
 const App = () => {
-  const { speak, stop } = useTTS();
+  const { speak, stop, togglePause, isSpeaking } = useTTS();
+
+  const handleSend = (message: string) => {
+    speak(message);
+  };
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        stop();
+      } else if (e.key === " " && !(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)) {
+        e.preventDefault();
+        togglePause();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [stop, togglePause]);
 
   return (
     <div className="flex min-h-screen bg-light-blue">
-      {/* LeftPanel wrapper already uses w-1/4 */}
       <LeftPanel />
-
-      {/* MainWindow with padding on right for RightBar space */}
       <main className="flex-1 p-4 pr-[8%] flex flex-col justify-between">
         <MainWindow />
-
-        {/* Temporary voice test controls */}
-        <div className="mt-4 space-x-4">
-          <button
-            onClick={speak}
-            className="bg-purple-600 text-white px-4 py-2 rounded shadow-md"
-          >
-            ▶️ Speak
-          </button>
-          <button
-            onClick={stop}
-            className="bg-gray-600 text-white px-4 py-2 rounded shadow-md"
-          >
-            ⏹ Stop
-          </button>
+        <div className="mt-4 space-y-2">
+          {isSpeaking && (
+            <div className="flex items-center gap-2 text-sm text-gray-600">
+              <span className="animate-pulse">🔊 Speaking...</span>
+              <button onClick={stop} className="text-red-600 underline">
+                Stop
+              </button>
+            </div>
+          )}
+          <InputBox onSend={handleSend} onStop={stop} />
         </div>
       </main>
-
-      {/* RightBar - presumably fixed width */}
       <RightBar />
     </div>
   );
 };
 
 export default App;
-  

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 
 interface Props {
   onSend: (message: string) => void;
+  onStop?: () => void;
 }
 
-const InputBox = ({ onSend }: Props) => {
+const InputBox = ({ onSend, onStop }: Props) => {
   const [input, setInput] = useState("");
 
   const handleSend = () => {
@@ -19,7 +20,10 @@ const InputBox = ({ onSend }: Props) => {
         type="text"
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && handleSend()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSend();
+          if (e.key === "Escape") onStop?.();
+        }}
         placeholder="Talk to Holly..."
         className="flex-1 border border-light-purple rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-medium-purple"
       />

--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -1,29 +1,128 @@
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 
-const AUDIO_URL = "http://127.0.0.1:8000/static/dummy.mp3";
+const LLM_URL = "http://localhost:3001/llm";
 
 export function useTTS() {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const mediaSourceRef = useRef<MediaSource | null>(null);
+  const sourceBufferRef = useRef<SourceBuffer | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
 
-  const speak = () => {
-    // Stop any current playback
+  // Ensure single global Audio instance
+  if (!audioRef.current) {
+    audioRef.current = new Audio();
+  }
+
+  const cleanup = () => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
     if (audioRef.current) {
       audioRef.current.pause();
-      audioRef.current.currentTime = 0;
+      audioRef.current.removeAttribute("src");
     }
-
-    // Start new audio
-    const audio = new Audio(AUDIO_URL);
-    audioRef.current = audio;
-    audio.play();
+    mediaSourceRef.current = null;
+    sourceBufferRef.current = null;
+    setIsSpeaking(false);
+    setIsPaused(false);
   };
 
   const stop = () => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.currentTime = 0;
+    cleanup();
+  };
+
+  const speak = async (prompt: string) => {
+    // Interrupt any current playback
+    stop();
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    const mediaSource = new MediaSource();
+    mediaSourceRef.current = mediaSource;
+
+    audioRef.current!.src = URL.createObjectURL(mediaSource);
+
+    setIsSpeaking(true);
+    setIsPaused(false);
+
+    mediaSource.addEventListener("sourceopen", async () => {
+      const sourceBuffer = mediaSource.addSourceBuffer("audio/mpeg");
+      sourceBufferRef.current = sourceBuffer;
+
+      try {
+        const response = await fetch(LLM_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          throw new Error("TTS request failed");
+        }
+
+        const reader = response.body.getReader();
+        const pump = async (): Promise<void> => {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) {
+              await new Promise<void>((resolve) => {
+                if (!sourceBuffer.updating) return resolve();
+                sourceBuffer.addEventListener("updateend", () => resolve(), {
+                  once: true,
+                });
+              });
+              mediaSource.endOfStream();
+              setIsSpeaking(false);
+              break;
+            }
+            if (value) {
+              await new Promise<void>((resolve) => {
+                sourceBuffer.addEventListener("updateend", () => resolve(), {
+                  once: true,
+                });
+                sourceBuffer.appendBuffer(value);
+              });
+            }
+          }
+        };
+
+        pump().catch((err) => {
+          if (controller.signal.aborted) return; // normal abort
+          console.error(err);
+          cleanup();
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return; // ignore abort errors
+        console.error(err);
+        cleanup();
+      }
+    });
+
+    try {
+      await audioRef.current!.play();
+    } catch (err) {
+      console.error(err);
+      cleanup();
     }
   };
 
-  return { speak, stop };
+  const togglePause = () => {
+    if (!audioRef.current) return;
+    if (audioRef.current.paused) {
+      audioRef.current.play();
+      setIsPaused(false);
+    } else {
+      audioRef.current.pause();
+      setIsPaused(true);
+    }
+  };
+
+  useEffect(() => {
+    return () => cleanup();
+  }, []);
+
+  return { speak, stop, togglePause, isSpeaking, isPaused };
 }


### PR DESCRIPTION
## Summary
- stream audio from `/llm` with MediaSource and global Audio element
- add stop, pause and speaking state controls with keyboard shortcuts
- integrate InputBox to trigger streaming TTS and show speaking status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c051f8b48329a99575e7ac94913b