### PR TITLE
Fix streaming TTS headers and media source setup

### DIFF
--- a/routes/llm.js
+++ b/routes/llm.js
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { spawn } from 'child_process';
+
+const router = Router();
+
+router.post('/', (req, res) => {
+  const { prompt } = req.body ?? {};
+
+  res.writeHead(200, {
+    'Content-Type': 'audio/mpeg',
+    'Transfer-Encoding': 'chunked',
+    'Connection': 'keep-alive',
+  });
+
+  const tts = spawn('python', ['tts.py'], { stdio: ['pipe', 'pipe', 'inherit'] });
+  if (prompt) {
+    tts.stdin.write(prompt);
+  }
+  tts.stdin.end();
+
+  tts.stdout.on('data', (chunk) => {
+    res.write(chunk);
+  });
+
+  tts.on('close', () => {
+    res.end();
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Ensure backend TTS route sets audio streaming headers and pipes `tts.py` output as MP3 chunks
- Initialize MediaSource with correct MP3 MIME type and validate support before streaming
- Safely append audio chunks to SourceBuffer while passing `stream: true` in fetch requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `curl http://localhost:3001/llm -H "Content-Type: application/json" -d '{"prompt": "Hello from Holly", "stream": true}' --output test.mp3` *(connection refused, backend not running)*

------
https://chatgpt.com/codex/tasks/task_e_6893d2c07a3c83298b8adf2857c6a800