### PR TITLE
Handle non-audio TTS responses gracefully

### DIFF
--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -71,7 +71,13 @@ export function useTTS() {
 
         const contentType = response.headers.get("Content-Type") || "";
         if (!contentType.includes("audio/mpeg")) {
-          throw new Error(`Invalid content-type: ${contentType}`);
+          const errorText = await response.text().catch(() => "");
+          console.error(
+            `TTS error: expected audio/mpeg but received ${contentType}`,
+            errorText,
+          );
+          cleanup();
+          return;
         }
 
         const reader = response.body.getReader();


### PR DESCRIPTION
## Summary
- Abort TTS playback when server response isn't `audio/mpeg`
- Log error details for easier debugging when non-audio responses occur

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689446b31cd483298794306a98a340f7