### PR TITLE
Handle non-audio TTS responses gracefully

### DIFF
--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -54,9 +54,6 @@ export function useTTS() {
         cleanup();
         return;
       }
-      const sourceBuffer = mediaSource.addSourceBuffer(mime);
-      sourceBufferRef.current = sourceBuffer;
-
       try {
         const response = await fetch(LLM_URL, {
           method: "POST",
@@ -79,6 +76,9 @@ export function useTTS() {
           cleanup();
           return;
         }
+
+        const sourceBuffer = mediaSource.addSourceBuffer(mime);
+        sourceBufferRef.current = sourceBuffer;
 
         const reader = response.body.getReader();
         let started = false;


### PR DESCRIPTION
## Summary
- Only create a media SourceBuffer after verifying the LLM response is `audio/mpeg`
- Log a helpful error and abort playback when the backend returns non-audio content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68944adcec1c832991612da55957ccf3