### PR TITLE
Ensure TTS uses streaming and surface errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.hollyai.xyz

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,7 +6,7 @@ import InputBox from "./components/InputBox";
 import { useTTS } from "./useTTS";
 
 const App = () => {
-  const { speak, stop, togglePause, isSpeaking } = useTTS();
+  const { speak, stop, togglePause, isSpeaking, error } = useTTS();
 
   const handleSend = (message: string) => {
     speak(message);
@@ -38,6 +38,9 @@ const App = () => {
                 Stop
               </button>
             </div>
+          )}
+          {error && (
+            <div className="text-sm text-red-600">Speech unavailable: {error}</div>
           )}
           <InputBox onSend={handleSend} onStop={stop} />
         </div>

--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -52,7 +52,7 @@ export function useTTS() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           mode: "cors",
-          body: JSON.stringify({ prompt: text }),
+          body: JSON.stringify({ prompt: text, stream: true }),
         });
 
         const contentType = res.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary
- Request TTS audio in streaming mode to avoid JSON responses
- Surface TTS failures in the main app UI
- Provide .env.example with default API base URL

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895c1e6b83083299b907483cac65279