### PR TITLE
Switch TTS hook to text payload

### DIFF
--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-// Backend endpoint that returns an MP3 stream for the provided prompt
+// Backend endpoint that returns an MP3 stream for the provided text
 // Prefer an environment variable so deployments can configure the API base
 const TTS_URL = import.meta.env.VITE_TTS_URL || "https://api.hollyai.xyz/tts";
 const ENABLE_FALLBACK =
@@ -53,7 +53,7 @@ export function useTTS() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           mode: "cors",
-          body: JSON.stringify({ prompt: text, stream: false }),
+          body: JSON.stringify({ text, stream: false }),
         });
 
         const contentType = res.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary
- Update `useTTS` to send `{ text, stream: false }` to `/tts` so backend speaks the exact reply
- Adjust comment to reflect new parameter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68964d0b8d208329a788e753cb0cee90