### PR TITLE
Fetch TTS audio as binary blobs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -19,9 +19,9 @@ const App = () => {
     selfTestAudio = async () => {
       const res = await fetch(`${base}/tts/selftest-text`);
       const ct = res.headers.get("content-type") || "audio/wav";
-      const buf = await res.arrayBuffer();
-      const blob = new Blob([buf], { type: ct });
-      const url = URL.createObjectURL(blob);
+      const blob = await res.blob();
+      const audioBlob = new Blob([blob], { type: ct });
+      const url = URL.createObjectURL(audioBlob);
       const audio = document.createElement("audio");
       audio.src = url;
       audio.onended = () => URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary
- Ensure TTS hook fetches audio as binary blob, creates object URL, and avoids text/JSON parsing
- Update self-test helper to use blob-based playback as well

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68967f69a5688329b4c704293a7cbfb5