### PR TITLE
Improve TTS error handling and text limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 VITE_API_URL=https://api.hollyai.xyz
 VITE_TTS_URL=https://api.hollyai.xyz/tts
+VITE_TTS_TEXT_MAX_CHARS=600
+VITE_TTS_SUMMARIZE=false
 VITE_STT_URL=https://stt.hollyai.xyz/listen
 VITE_ENABLE_TTS_FALLBACK=false
 VITE_LOG_VOICE_DEBUG=false

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,9 +4,10 @@ import MainWindow from "./components/MainWindow";
 import RightBar from "./components/RightBar";
 import InputBox from "./components/InputBox";
 import { useTTS, TTS_URL } from "./useTTS";
+import Toast from "./components/Toast";
 
 const App = () => {
-  const { speak, stop, togglePause, isSpeaking, error } = useTTS();
+  const { speak, stop, togglePause, isSpeaking } = useTTS();
 
   let selfTestJson: (() => Promise<void>) | undefined;
   let selfTestAudio: (() => Promise<void>) | undefined;
@@ -60,9 +61,6 @@ const App = () => {
               </button>
             </div>
           )}
-          {error && (
-            <div className="text-sm text-red-600">Speech unavailable: {error}</div>
-          )}
           <InputBox onSend={handleSend} onStop={stop} />
           {import.meta.env.DEV && (
             <div className="flex gap-2 text-xs">
@@ -77,6 +75,7 @@ const App = () => {
         </div>
       </main>
       <RightBar />
+      <Toast />
     </div>
   );
 };

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -15,7 +15,7 @@ const LeftPanel = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isThinking, setIsThinking] = useState(false);
   const [mode, setMode] = useState<"text" | "voice">("text");
-  const { speak, stop, isSpeaking, isLoading, error } = useTTS();
+  const { speak, stop, isSpeaking, isLoading } = useTTS();
 
   // Handle STT return → same handler as text input
   const handleSend = (input: string) => {
@@ -140,11 +140,6 @@ const LeftPanel = () => {
       {isLoading && (
         <div className="flex items-center justify-center text-sm text-gray-500">
           Loading speech…
-        </div>
-      )}
-      {error && (
-        <div className="flex items-center justify-center text-sm text-red-600">
-          Speech unavailable: {error}
         </div>
       )}
       {isSpeaking && !isLoading && (

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+const Toast = () => {
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let timeout: number | undefined;
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      setMessage(detail);
+      clearTimeout(timeout);
+      timeout = window.setTimeout(() => setMessage(null), 3000);
+    };
+    window.addEventListener("app-toast", handler as EventListener);
+    return () => {
+      window.removeEventListener("app-toast", handler as EventListener);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-3 py-2 rounded shadow text-sm">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchLLMResponse } from "./api/llm";
 
 // Backend endpoint that returns an MP3 stream for the provided text
 // Prefer an environment variable so deployments can configure the API base
@@ -6,6 +7,9 @@ export const TTS_URL =
   import.meta.env.VITE_TTS_URL || "https://api.hollyai.xyz/tts";
 const ENABLE_FALLBACK =
   import.meta.env.VITE_ENABLE_TTS_FALLBACK === "true";
+const TTS_TEXT_MAX_CHARS =
+  Number(import.meta.env.VITE_TTS_TEXT_MAX_CHARS) || 600;
+const TTS_SUMMARIZE = import.meta.env.VITE_TTS_SUMMARIZE === "true";
 
 /**
  * Simple hook to turn text into speech using the backend TTS service.
@@ -49,25 +53,47 @@ export function useTTS() {
       setIsLoading(true);
       setError(null);
 
+      let ttsText = text;
+
+      if (TTS_SUMMARIZE) {
+        try {
+          ttsText = await fetchLLMResponse(
+            `Summarize the following for a spoken response in 2-3 sentences:\n\n${text}`
+          );
+        } catch (err) {
+          console.warn("TTS summarize failed:", err);
+          ttsText = text;
+        }
+      }
+
+      if (ttsText.length > TTS_TEXT_MAX_CHARS) {
+        console.warn(
+          `TTS text too long: ${ttsText.length}, truncating to ${TTS_TEXT_MAX_CHARS}`
+        );
+        ttsText = ttsText.slice(0, TTS_TEXT_MAX_CHARS) + "…";
+      }
+
+      if (import.meta.env.DEV) {
+        console.log(`[tts] text length: ${ttsText.length}`);
+      }
+
       try {
         const res = await fetch(TTS_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           mode: "cors",
-          body: JSON.stringify({ text, stream: false }),
+          body: JSON.stringify({ text: ttsText, stream: false }),
         });
 
         if (!res.ok) {
-          let message = `TTS request failed: ${res.status}`;
+          let errJson: any = {};
           try {
-            const errBuf = await res.arrayBuffer();
-            const errText = new TextDecoder().decode(errBuf);
-            console.log({ stage: "error", error: errText, status: res.status });
-            if (errText) message = errText;
+            errJson = await res.json();
           } catch (parseErr) {
-            console.log({ stage: "parse", error: (parseErr as Error).message, status: res.status });
+            errJson = { error: (parseErr as Error).message };
           }
-          throw new Error(message);
+          console.log({ stage: "tts", ...errJson, status: res.status });
+          throw new Error(errJson.error || `TTS request failed: ${res.status}`);
         }
 
         const ct = res.headers.get("content-type") || "audio/wav";
@@ -86,7 +112,7 @@ export function useTTS() {
         setIsSpeaking(true);
       } catch (err) {
         console.error("TTS Error:", err);
-        const message = (err as Error).message;
+        const message = (err as Error).message || "Voice timed out. Try again.";
         setError(message);
         if (
           ENABLE_FALLBACK &&
@@ -94,7 +120,7 @@ export function useTTS() {
           "speechSynthesis" in window
         ) {
           try {
-            const utterance = new SpeechSynthesisUtterance(text);
+            const utterance = new SpeechSynthesisUtterance(ttsText);
             utterance.onend = cleanup;
             speechSynthesis.speak(utterance);
             setIsSpeaking(true);
@@ -103,6 +129,9 @@ export function useTTS() {
             console.error("speechSynthesis error:", fallbackErr);
           }
         }
+        window.dispatchEvent(
+          new CustomEvent("app-toast", { detail: message })
+        );
         cleanup();
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- Limit TTS text to configurable max characters and optionally summarize before speech
- Add toast notifications and better error logging for TTS failures
- Expose new TTS environment toggles in `.env.example`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896f8ae34b08329b32c3a0103cc2ead